### PR TITLE
Support Puppet >= 4.9 & Ruby 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.3.1
 
 env:
   matrix:
@@ -24,12 +25,15 @@ env:
     - PUPPET_GEM_VERSION="~> 4.3.0"
     - PUPPET_GEM_VERSION="~> 4.4.0"
     - PUPPET_GEM_VERSION="~> 4.5.0"
+    - PUPPET_GEM_VERSION="~> 4.6.0"
+    - PUPPET_GEM_VERSION="~> 4.7.0"
+    - PUPPET_GEM_VERSION="~> 4.8.0"
+    - PUPPET_GEM_VERSION="~> 4.9.0"
     - PUPPET_GEM_VERSION="~> 4"
-    - PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
 
 sudo: false
 
-script: 'bundle exec metadata-json-lint metadata.json && bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
+script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
 
 matrix:
   fast_finish: true
@@ -57,9 +61,41 @@ matrix:
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4.5.0"
     - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4"
+      env: PUPPET_GEM_VERSION="~> 4.6.0"
     - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
+      env: PUPPET_GEM_VERSION="~> 4.7.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.8.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.9.0"
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 4.9.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 4.9.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4"
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 4"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 4"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.3.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.4.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.5.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.6.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.7.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.8.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
 
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,21 +1,31 @@
-source 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-if puppetversion = ENV['PUPPET_GEM_VERSION']
-  gem 'puppet', puppetversion, :require => false
+if ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', ENV['PUPPET_GEM_VERSION'], :require => false
 else
   gem 'puppet', :require => false
 end
 
-gem 'metadata-json-lint'
-gem 'puppetlabs_spec_helper', '>= 0.1.0'
-gem 'puppet-lint', '>= 1.0.0'
-gem 'facter', '>= 1.7.0'
-gem 'rspec-puppet'
 gem 'rspec-puppet-facts', :require => false
+gem 'puppetlabs_spec_helper', '>= 1.2.0', :require => false
+gem 'facter', '>= 1.7.0', :require => false
+gem 'rspec-puppet', :require => false
+gem 'puppet-lint', '~> 2.0', :require => false
+gem 'puppet-lint-absolute_classname-check', :require => false
+gem 'puppet-lint-alias-check', :require => false
+gem 'puppet-lint-empty_string-check', :require => false
+gem 'puppet-lint-file_ensure-check', :require => false
+gem 'puppet-lint-file_source_rights-check', :require => false
+gem 'puppet-lint-leading_zero-check', :require => false
+gem 'puppet-lint-spaceship_operator_without_tag-check', :require => false
+gem 'puppet-lint-trailing_comma-check', :require => false
+gem 'puppet-lint-undef_in_function-check', :require => false
+gem 'puppet-lint-unquoted_string-check', :require => false
+gem 'puppet-lint-variable_contains_upcase', :require => false
 
-# rspec must be v2 for ruby 1.8.7
-if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
-  gem 'rspec', '~> 2.0'
-  # rake >= 11 does not support ruby 1.8.7
-  gem 'rake', '~> 10.0'
-end
+gem 'rspec',              '~> 2.0',   :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'rake',               '~> 10.0',  :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'json',               '<= 1.8',   :require => false if RUBY_VERSION < '2.0.0'
+gem 'json_pure',          '<= 2.0.1', :require => false if RUBY_VERSION < '2.0.0'
+gem 'metadata-json-lint', '0.0.11',   :require => false if RUBY_VERSION < '1.9'
+gem 'metadata-json-lint',             :require => false if RUBY_VERSION >= '1.9'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
+
 PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
 PuppetLint.configuration.relative = true
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,8 +77,8 @@ class nfsclient (
   }
 
   if $gss_real {
-    include rpcbind
-    include nfs::idmap
+    include ::rpcbind
+    include ::nfs::idmap
 
     file_line { 'NFS_SECURITY_GSS':
       path   => '/etc/sysconfig/nfs',


### PR DESCRIPTION
This change also align the testing rig.

See original PR against old "master repo":
https://github.com/gillarkod/puppet-module-nfsclient/pull/4

We'll transfer the pending merge of Phil's changes to this new repo now.