### PR TITLE
Support EL9 (again)

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,7 +7,7 @@ fixtures:
       repo: 'https://github.com/ghoneycutt/puppet-module-rpcbind.git'
       ref: 'v3.0.0'
     nfs:
-      repo: 'https://github.com/ghoneycutt/puppet-module-nfs.git'
-      ref: 'v2.3.0'
+      repo: 'https://github.com/kodguru/puppet-module-nfs.git'
+      ref: 'v2.4.0'
   symlinks:
     nfsclient: "#{source_dir}"

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,5 +1,5 @@
 ---
-nfsclient::service_name:      'auth-rpcgss-module.service'
+nfsclient::service_name:      'gssproxy'
 nfsclient::gss_line:          'SECURE_NFS'
 nfsclient::keytab_line:       'RPCGSSDARGS'
 nfsclient::nfs_config_method: 'service'

--- a/data/os/RedHat/8.yaml
+++ b/data/os/RedHat/8.yaml
@@ -1,0 +1,2 @@
+---
+nfsclient::service_name: 'auth-rpcgss-module.service'

--- a/metadata.json
+++ b/metadata.json
@@ -17,8 +17,8 @@
       "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
-      "name": "ghoneycutt/nfs",
-      "version_requirement": ">= 2.3.0 < 3.0.0"
+      "name": "kodguru/nfs",
+      "version_requirement": ">= 2.4.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -43,7 +43,8 @@
       "operatingsystemrelease": [
         "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,7 +8,6 @@ describe 'nfsclient', type: :class do
       # define os specific defaults
       case facts[:os]['family']
       when 'RedHat'
-        service_name      = 'auth-rpcgss-module.service'
         gss_line          = 'SECURE_NFS'
         keytab_line       = 'RPCGSSDARGS'
         nfs_requires      = 'Service[idmapd_service]'
@@ -18,8 +17,12 @@ describe 'nfsclient', type: :class do
           nfs_config_method = 'sysconfig'
         when '7'
           nfs_config_method = 'sysconfig'
+        when '8'
+          nfs_config_method = 'service'
+          service_name      = 'auth-rpcgss-module.service'
         else
           nfs_config_method = 'service'
+          service_name      = 'gssproxy'
         end
       when 'Suse'
         gss_line          = 'NFS_SECURITY_GSS'


### PR DESCRIPTION
We missed that #15  silently dropped support for EL9. It appears to be because it was  never added to metadata.json.

This pull request adds EL9 support again. Had to change puppet-module-nfs fixtures to our fork for EL9 support.