### PR TITLE
Fix issue with include_nfs_config

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,7 +144,7 @@ class nfsclient (
       }
     }
 
-    if include_nfs_config {
+    if $include_nfs_config {
       exec { 'nfs-config':
         command     => 'service nfs-config start',
         path        => '/sbin:/usr/sbin',


### PR DESCRIPTION
With the current setup the code always enters the  'include_nfs_config' code path because a dollar sign is missing in front of the variable name.  Also updates the spec test to better test this.